### PR TITLE
Hotfix slurm

### DIFF
--- a/scripts/slurm.py
+++ b/scripts/slurm.py
@@ -55,7 +55,7 @@ def getJobScript(parallel: str):
 #SBATCH --signal=B:SIGTERM@180
 
 cd {cwd}
-srun --ntasks=$SLURM_NNODES --ntasks-per-node=1 tar -xf {venv_origin} -C {venv}
+tar -xf {venv_origin} -C {venv}
 
 export MPLBACKEND=TKAgg
 export OMP_NUM_THREADS=1


### PR DESCRIPTION
srun: error: cli_filter/lua: Unable to stat /var/spool/slurmd/conf-cache/cli_filter.lua: No such file or directory
srun: error: Couldn't load specified plugin name for cli_filter/lua: Plugin init() callback failed
srun: error: cannot create cli_filter context for cli_filter/lua
srun: fatal: failed to initialize cli_filter plugin
/var/spool/slurmd/job1219608/slurm_script: line 11: /tmp/.venv/bin/python: No such file or directory