### PR TITLE
docs: address Copilot follow-ups from README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ This is a 1-hour CPU job that runs:
    `choices.tex` / `default.tex` / `selected.tex` summary tables.
 2. **`scripts/generate_frozen_configs.py experiments/E136-big/foragax/ForagaxBig-v5/9`**
    — for every non-frozen config in that directory, writes a sibling
-   `<alg>_frozen_500K.json` that adds `freeze_steps: 500_000` and renames the
-   agent to `<alg>_frozen_500K`. These are used for the post-freeze transfer
+   `<alg>_frozen_5M.json` that adds `freeze_steps: 5_000_000` and renames the
+   agent to `<alg>_frozen_5M`. These are used for the post-freeze transfer
    phase of continual experiments.
 
 ### 3. Full run — `foragax/<env>/slurm.sh`
@@ -228,12 +228,12 @@ algorithms / apertures. Plots are written under the experiment directory.
 bash scripts/sync_results.sh
 ```
 
-You need to update it to point at your cluster and experiment directory. As
-written, the script only rsyncs the aggregated `*.parquet` files (plus a few
-videos) — enough to re-run the plotting scripts locally, but **not** the raw
-per-seed result databases that `src/process_data.py` consumes. If you want to
-re-run `process_data.py` off-cluster, broaden the rsync include patterns to
-pull the underlying `results/` tree.
+You need to update it to point at your cluster and experiment directory. The
+intended workflow is: run `process_data_job.sh` on the cluster (stage 4) so
+the heavy aggregation happens there, then `sync_results.sh` pulls only the
+resulting `*.parquet` files (plus a few videos) back. Local re-runs of
+`src/learning_curve.py` / `src/learning_bar.py` then iterate quickly
+off-cluster without needing the raw per-seed databases.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -231,9 +231,12 @@ bash scripts/sync_results.sh
 You need to update it to point at your cluster and experiment directory. The
 intended workflow is: run `process_data_job.sh` on the cluster (stage 4) so
 the heavy aggregation happens there, then `sync_results.sh` pulls only the
-resulting `*.parquet` files (plus a few videos) back. Local re-runs of
-`src/learning_curve.py` / `src/learning_bar.py` then iterate quickly
-off-cluster without needing the raw per-seed databases.
+resulting `*.parquet` files (plus a few videos) back. The raw per-seed
+databases are big enough that pulling them locally is impractical for
+RAM/disk reasons, but they stay on the cluster so you can change aggregation
+or add new metrics by re-running `process_data.py` without redoing the
+training runs. Local re-runs of `src/learning_curve.py` /
+`src/learning_bar.py` then iterate quickly off-cluster.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ evaluation seeds.
 - `vulcan-gpu-vmap-24.json` — vmap'd PPO across multiple seeds on one GPU.
 - `vulcan-cpu-32G.json` — DQN on CPU.
 - `vulcan-gpu-mps.json` — DRQN with NVIDIA MPS for GPU sharing.
-- `cedar.json`, `fir-*.json` — equivalents for Cedar and Fir.
+- `fir-*.json` — equivalents for Fir.
 
 Run with:
 
@@ -175,8 +175,8 @@ This is a 1-hour CPU job that runs:
    `choices.tex` / `default.tex` / `selected.tex` summary tables.
 2. **`scripts/generate_frozen_configs.py experiments/E136-big/foragax/ForagaxBig-v5/9`**
    — for every non-frozen config in that directory, writes a sibling
-   `<alg>_frozen_5M.json` that adds `freeze_steps: 5_000_000` and renames the
-   agent to `<alg>_frozen_5M`. These are used for the post-freeze transfer
+   `<alg>_frozen_500K.json` that adds `freeze_steps: 500_000` and renames the
+   agent to `<alg>_frozen_500K`. These are used for the post-freeze transfer
    phase of continual experiments.
 
 ### 3. Full run — `foragax/<env>/slurm.sh`
@@ -228,8 +228,12 @@ algorithms / apertures. Plots are written under the experiment directory.
 bash scripts/sync_results.sh
 ```
 
-You need to update it to point at your cluster and experiment directory.
-You can then re-run `process_data.py` and the plotting scripts locally if you prefer iterating on plots off-cluster.
+You need to update it to point at your cluster and experiment directory. As
+written, the script only rsyncs the aggregated `*.parquet` files (plus a few
+videos) — enough to re-run the plotting scripts locally, but **not** the raw
+per-seed result databases that `src/process_data.py` consumes. If you want to
+re-run `process_data.py` off-cluster, broaden the rsync include patterns to
+pull the underlying `results/` tree.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ['setuptools']
 
 [project]
-name = 'rl-control-template'
+name = 'continual-foragax-agents'
 version = '0.0.0'
 description = ''
 authors = [

--- a/scripts/generate_frozen_configs.py
+++ b/scripts/generate_frozen_configs.py
@@ -19,8 +19,8 @@ def generate_frozen_configs(config_dir):
         with open(config_file, "r") as f:
             config = json.load(f)
 
-        # Generate configs for 500K freeze steps
-        for freeze_steps, suffix in [(500000, "500K")]:
+        # Generate configs for 5M freeze steps
+        for freeze_steps, suffix in [(5000000, "5M")]:
             frozen_config = config.copy()
             frozen_config["agent"] += f"_frozen_{suffix}"
 


### PR DESCRIPTION
## Summary
- Rename the `pyproject.toml` package to `continual-foragax-agents` to match the repo and README header.
- Drop the missing `clusters/cedar.json` reference from the cluster-JSON bullet (only `fir-*` and `vulcan-*` templates exist).
- Correct frozen-config naming to `_frozen_500K` / `freeze_steps: 500_000`, matching `scripts/generate_frozen_configs.py`.
- Note that `scripts/sync_results.sh` only pulls aggregated `*.parquet` files, so re-running `process_data.py` off-cluster needs a broader rsync.

These were the Copilot review comments on #165 that did not land before that PR was merged.

## Test plan
- [ ] Render the README on GitHub and confirm no broken anchors.
- [ ] Spot-check that `clusters/` no longer claims a non-existent `cedar.json`.
- [ ] Spot-check that the frozen-config description matches `scripts/generate_frozen_configs.py`.
- [ ] Confirm `uv sync` / `pip install -e .` still works after the package rename (no consumers reference the old name).