### PR TITLE
feat: auto-detect SLURM account via sacctmgr

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,12 @@ cd continual-foragax-agents
    `pip install -e .` in `$SLURM_TMPDIR`, then copies the resulting `.venv`
    back into the project directory).
 
-> **Edit before running.** `scripts/local_node_venv.sh` and the per-experiment
-> `*_job.sh` files hardcode a CC allocation account (`rrg-whitem`,
-> `aip-amw8`). Change the `--account=` line to your own allocation before
-> submitting anything.
+> **Allocation accounts.** `scripts/slurm.py` auto-detects your SLURM
+> account from `sacctmgr` (priority `rrg-` > `aip-` > `def-`, randomized
+> within a tier per job to spread load). Pass `--account=<name>` on the
+> CLI to pin a specific account. `scripts/local_node_venv.sh` and the
+> per-experiment `*_job.sh` files still hardcode `--account=` and need
+> manual edits.
 
 Wait for the build job to finish, confirm there is a `.venv/` in the project
 root, and you are ready to schedule sweeps. Each new shell needs:

--- a/clusters/fir-1h-c8-t1-m2-s1.json
+++ b/clusters/fir-1h-c8-t1-m2-s1.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "1:00:00",
     "cores": 8,
     "mem_per_core": "2G",

--- a/clusters/fir-1h-c8-t1-m2-s128.json
+++ b/clusters/fir-1h-c8-t1-m2-s128.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "1:00:00",
     "cores": 8,
     "mem_per_core": "2G",

--- a/clusters/fir-1h-c8-t1-m2-s2.json
+++ b/clusters/fir-1h-c8-t1-m2-s2.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "1:00:00",
     "cores": 8,
     "mem_per_core": "2G",

--- a/clusters/fir-1h-c8-t1-m2-s32.json
+++ b/clusters/fir-1h-c8-t1-m2-s32.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "1:00:00",
     "cores": 8,
     "mem_per_core": "2G",

--- a/clusters/fir-1h-c8-t1-m2-s4.json
+++ b/clusters/fir-1h-c8-t1-m2-s4.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "1:00:00",
     "cores": 8,
     "mem_per_core": "2G",

--- a/clusters/fir-1h-c8-t8-m2-s1.json
+++ b/clusters/fir-1h-c8-t8-m2-s1.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "1:00:00",
     "cores": 8,
     "threads_per_task": 8,

--- a/clusters/fir-cpu-10h.json
+++ b/clusters/fir-cpu-10h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "10:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-12h.json
+++ b/clusters/fir-cpu-12h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "12:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-15m.json
+++ b/clusters/fir-cpu-15m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "0:15:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-1d.json
+++ b/clusters/fir-cpu-1d.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "24:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-1h.json
+++ b/clusters/fir-cpu-1h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "1:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-2h.json
+++ b/clusters/fir-cpu-2h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "2:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-30m.json
+++ b/clusters/fir-cpu-30m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "0:30:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-3h.json
+++ b/clusters/fir-cpu-3h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "3:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-45m.json
+++ b/clusters/fir-cpu-45m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "0:45:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-4h.json
+++ b/clusters/fir-cpu-4h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "4:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-5h.json
+++ b/clusters/fir-cpu-5h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "5:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-6h.json
+++ b/clusters/fir-cpu-6h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "6:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-7h.json
+++ b/clusters/fir-cpu-7h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "7:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-8h.json
+++ b/clusters/fir-cpu-8h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "8:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-cpu-9h.json
+++ b/clusters/fir-cpu-9h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "8:00:00",
     "cores": 192,
     "mem_per_core": "3G",

--- a/clusters/fir-gpu-mps-1h.json
+++ b/clusters/fir-gpu-mps-1h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "1:00:00",
     "gpus": "nvidia_h100_80gb_hbm3_1g.10gb:1",
     "cores": 3,

--- a/clusters/fir-gpu-mps-3h.json
+++ b/clusters/fir-gpu-mps-3h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "3:00:00",
     "gpus": "nvidia_h100_80gb_hbm3_1g.10gb:1",
     "cores": 3,

--- a/clusters/fir-gpu-mps-6h.json
+++ b/clusters/fir-gpu-mps-6h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "6:00:00",
     "gpus": "nvidia_h100_80gb_hbm3_1g.10gb:1",
     "cores": 3,

--- a/clusters/fir-gpu-mps-8h.json
+++ b/clusters/fir-gpu-mps-8h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "8:00:00",
     "gpus": "nvidia_h100_80gb_hbm3_1g.10gb:1",
     "cores": 3,

--- a/clusters/optuna_cedar.json
+++ b/clusters/optuna_cedar.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "rrg-whitem",
     "time": "2:59:00",
     "cores": 10,
     "mem_per_core": "2G",

--- a/clusters/vulcan-cpu-10h.json
+++ b/clusters/vulcan-cpu-10h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "10:00:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu-12h.json
+++ b/clusters/vulcan-cpu-12h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "12:00:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu-15m.json
+++ b/clusters/vulcan-cpu-15m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:15:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu-16G.json
+++ b/clusters/vulcan-cpu-16G.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "cores": 16,
     "mem_per_core": "16G",

--- a/clusters/vulcan-cpu-1d.json
+++ b/clusters/vulcan-cpu-1d.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "24:00:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu-1h.json
+++ b/clusters/vulcan-cpu-1h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "cores": 8,
     "mem_per_core": "16G",

--- a/clusters/vulcan-cpu-2h.json
+++ b/clusters/vulcan-cpu-2h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "2:00:00",
     "cores": 8,
     "mem_per_core": "16G",

--- a/clusters/vulcan-cpu-30m.json
+++ b/clusters/vulcan-cpu-30m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:30:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu-32G.json
+++ b/clusters/vulcan-cpu-32G.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "cores": 8,
     "mem_per_core": "32G",

--- a/clusters/vulcan-cpu-3h.json
+++ b/clusters/vulcan-cpu-3h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "3:00:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu-45m.json
+++ b/clusters/vulcan-cpu-45m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:45:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu-4h.json
+++ b/clusters/vulcan-cpu-4h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "4:00:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu-5h.json
+++ b/clusters/vulcan-cpu-5h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "5:00:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu-6h.json
+++ b/clusters/vulcan-cpu-6h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "6:00:00",
     "cores": 8,
     "mem_per_core": "16G",

--- a/clusters/vulcan-cpu-7h.json
+++ b/clusters/vulcan-cpu-7h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "7:00:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu-8h.json
+++ b/clusters/vulcan-cpu-8h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "8:00:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu-9h.json
+++ b/clusters/vulcan-cpu-9h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "9:00:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-cpu.json
+++ b/clusters/vulcan-cpu.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "cores": 16,
     "mem_per_core": "8G",

--- a/clusters/vulcan-foragax-high.json
+++ b/clusters/vulcan-foragax-high.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "23:59:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-foragax-mid.json
+++ b/clusters/vulcan-foragax-mid.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "11:59:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-foragax-sweep-high.json
+++ b/clusters/vulcan-foragax-sweep-high.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "11:59:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-foragax-sweep-mid.json
+++ b/clusters/vulcan-foragax-sweep-mid.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:59:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-foragax-upper.json
+++ b/clusters/vulcan-foragax-upper.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "23:59:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-mps-1d.json
+++ b/clusters/vulcan-gpu-mps-1d.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "24:00:00",
     "gpus": 1,
     "cores": 16,

--- a/clusters/vulcan-gpu-mps-1h.json
+++ b/clusters/vulcan-gpu-mps-1h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 16,

--- a/clusters/vulcan-gpu-mps-2h.json
+++ b/clusters/vulcan-gpu-mps-2h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "2:00:00",
     "gpus": 1,
     "cores": 16,

--- a/clusters/vulcan-gpu-mps-3h.json
+++ b/clusters/vulcan-gpu-mps-3h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "3:00:00",
     "gpus": 1,
     "cores": 16,

--- a/clusters/vulcan-gpu-mps-6h.json
+++ b/clusters/vulcan-gpu-mps-6h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "6:00:00",
     "gpus": 1,
     "cores": 16,

--- a/clusters/vulcan-gpu-mps-8h.json
+++ b/clusters/vulcan-gpu-mps-8h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "8:00:00",
     "gpus": 1,
     "cores": 16,

--- a/clusters/vulcan-gpu-mps-high.json
+++ b/clusters/vulcan-gpu-mps-high.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "24:00:00",
     "gpus": 1,
     "cores": 8,

--- a/clusters/vulcan-gpu-mps-lower.json
+++ b/clusters/vulcan-gpu-mps-lower.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 16,

--- a/clusters/vulcan-gpu-mps-mid-lower.json
+++ b/clusters/vulcan-gpu-mps-mid-lower.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:40:00",
     "gpus": 1,
     "cores": 16,

--- a/clusters/vulcan-gpu-mps-mid.json
+++ b/clusters/vulcan-gpu-mps-mid.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:50:00",
     "gpus": 1,
     "cores": 6,

--- a/clusters/vulcan-gpu-mps.json
+++ b/clusters/vulcan-gpu-mps.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 16,

--- a/clusters/vulcan-gpu-vmap-10.json
+++ b/clusters/vulcan-gpu-vmap-10.json
@@ -1,6 +1,5 @@
 {
     "type": "single_node",
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 4,

--- a/clusters/vulcan-gpu-vmap-10m.json
+++ b/clusters/vulcan-gpu-vmap-10m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:10:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-128.json
+++ b/clusters/vulcan-gpu-vmap-128.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-1h-35.json
+++ b/clusters/vulcan-gpu-vmap-1h-35.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-1h-70.json
+++ b/clusters/vulcan-gpu-vmap-1h-70.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-1h-high.json
+++ b/clusters/vulcan-gpu-vmap-1h-high.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-1h.json
+++ b/clusters/vulcan-gpu-vmap-1h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-1h30m-higher.json
+++ b/clusters/vulcan-gpu-vmap-1h30m-higher.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:30:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-1h30m.json
+++ b/clusters/vulcan-gpu-vmap-1h30m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:30:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-20m-8.json
+++ b/clusters/vulcan-gpu-vmap-20m-8.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:20:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-20m-high.json
+++ b/clusters/vulcan-gpu-vmap-20m-high.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:20:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-20m.json
+++ b/clusters/vulcan-gpu-vmap-20m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:20:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-24.json
+++ b/clusters/vulcan-gpu-vmap-24.json
@@ -1,6 +1,5 @@
 {
     "type": "single_node",
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 4,

--- a/clusters/vulcan-gpu-vmap-256.json
+++ b/clusters/vulcan-gpu-vmap-256.json
@@ -1,6 +1,5 @@
 {
     "type": "single_node",
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 4,

--- a/clusters/vulcan-gpu-vmap-2h-70.json
+++ b/clusters/vulcan-gpu-vmap-2h-70.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "2:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-2h-higher.json
+++ b/clusters/vulcan-gpu-vmap-2h-higher.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "2:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-2h.json
+++ b/clusters/vulcan-gpu-vmap-2h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "2:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-30m-high-512.json
+++ b/clusters/vulcan-gpu-vmap-30m-high-512.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:30:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-30m-high.json
+++ b/clusters/vulcan-gpu-vmap-30m-high.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:30:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-30m.json
+++ b/clusters/vulcan-gpu-vmap-30m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:30:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-32.json
+++ b/clusters/vulcan-gpu-vmap-32.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-3h-15.json
+++ b/clusters/vulcan-gpu-vmap-3h-15.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "3:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-3h-5.json
+++ b/clusters/vulcan-gpu-vmap-3h-5.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "3:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-3h-high.json
+++ b/clusters/vulcan-gpu-vmap-3h-high.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "3:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-3h.json
+++ b/clusters/vulcan-gpu-vmap-3h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "3:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-3h30m.json
+++ b/clusters/vulcan-gpu-vmap-3h30m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "3:30:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-40m-higher.json
+++ b/clusters/vulcan-gpu-vmap-40m-higher.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:40:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-45m-high.json
+++ b/clusters/vulcan-gpu-vmap-45m-high.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:45:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-45m.json
+++ b/clusters/vulcan-gpu-vmap-45m.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "0:45:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-4h.json
+++ b/clusters/vulcan-gpu-vmap-4h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "4:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-5.json
+++ b/clusters/vulcan-gpu-vmap-5.json
@@ -1,6 +1,5 @@
 {
     "type": "single_node",
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 4,

--- a/clusters/vulcan-gpu-vmap-512.json
+++ b/clusters/vulcan-gpu-vmap-512.json
@@ -1,6 +1,5 @@
 {
     "type": "single_node",
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 4,

--- a/clusters/vulcan-gpu-vmap-64.json
+++ b/clusters/vulcan-gpu-vmap-64.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "1:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-6h-15.json
+++ b/clusters/vulcan-gpu-vmap-6h-15.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "6:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-6h-30.json
+++ b/clusters/vulcan-gpu-vmap-6h-30.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "6:00:00",
     "gpus": 1,
     "cores": 1,

--- a/clusters/vulcan-gpu-vmap-6h.json
+++ b/clusters/vulcan-gpu-vmap-6h.json
@@ -1,7 +1,5 @@
 {
     "type": "single_node",
-
-    "account": "aip-amw8",
     "time": "6:00:00",
     "gpus": 1,
     "cores": 1,

--- a/scripts/runner/Slurm.py
+++ b/scripts/runner/Slurm.py
@@ -53,7 +53,13 @@ def _sacctmgr_accounts() -> tuple[str, ...]:
         for line in (l.strip() for l in result.stdout.splitlines())
         if line
     }
-    return tuple(sorted(bare))
+    matching = tuple(sorted(a for a in bare if a.startswith(_ACCOUNT_PRIORITY)))
+    if bare and not matching:
+        print(
+            "WARNING: no rrg-/aip-/def- account found in sacctmgr output; --account will be omitted",
+            file=sys.stderr,
+        )
+    return matching
 
 
 def auto_detect_account() -> str | None:
@@ -64,10 +70,6 @@ def auto_detect_account() -> str | None:
         candidates = [a for a in accounts if a.startswith(prefix)]
         if candidates:
             return random.choice(candidates)
-    print(
-        "WARNING: no rrg-/aip-/def- account found in sacctmgr output; --account will be omitted",
-        file=sys.stderr,
-    )
     return None
 
 
@@ -106,6 +108,7 @@ def fromFile(path: str):
 
     assert "type" in d, "Need to specify scheduling strategy."
     t = d.pop("type")
+    # account is set per-job from CLI/auto-detect, never JSON
     d["account"] = ""
 
     if t == "single_node":

--- a/scripts/runner/Slurm.py
+++ b/scripts/runner/Slurm.py
@@ -1,6 +1,10 @@
+import functools
 import json
 import math
 import os
+import random
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
@@ -23,12 +27,54 @@ class MultiNodeOptions(Slurm.MultiNodeOptions):
     tasks_per_vmap: int = 1
 
 
-def check_account(account: str):
-    assert (
-        account.startswith("rrg-")
-        or account.startswith("def-")
-        or account.startswith("aip-")
+_ACCOUNT_PRIORITY = ("rrg-", "aip-", "def-")
+
+
+@functools.lru_cache(maxsize=1)
+def _sacctmgr_accounts() -> tuple[str, ...]:
+    user = os.environ.get("USER", "")
+    try:
+        result = subprocess.run(
+            ["sacctmgr", "-nP", "show", "assoc", f"user={user}", "format=account"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        print(
+            f"WARNING: could not query sacctmgr ({e}); --account will be omitted",
+            file=sys.stderr,
+        )
+        return ()
+
+    bare = {
+        line.removesuffix("_cpu").removesuffix("_gpu")
+        for line in (l.strip() for l in result.stdout.splitlines())
+        if line
+    }
+    return tuple(sorted(bare))
+
+
+def auto_detect_account() -> str | None:
+    accounts = _sacctmgr_accounts()
+    if not accounts:
+        return None
+    for prefix in _ACCOUNT_PRIORITY:
+        candidates = [a for a in accounts if a.startswith(prefix)]
+        if candidates:
+            return random.choice(candidates)
+    print(
+        "WARNING: no rrg-/aip-/def- account found in sacctmgr output; --account will be omitted",
+        file=sys.stderr,
     )
+    return None
+
+
+def check_account(account: str):
+    if not account:
+        return
+    assert account.startswith(_ACCOUNT_PRIORITY)
     assert not account.endswith("_cpu") and not account.endswith("_gpu")
 
 
@@ -59,8 +105,8 @@ def fromFile(path: str):
         d = json.load(f)
 
     assert "type" in d, "Need to specify scheduling strategy."
-    t = d["type"]
-    del d["type"]
+    t = d.pop("type")
+    d["account"] = ""
 
     if t == "single_node":
         return SingleNodeOptions(**d)
@@ -78,8 +124,10 @@ def to_cmdline_flags(
     if not skip_validation:
         validate(options)
 
-    args = [
-        ("--account", options.account),
+    args: list[tuple[str, Any]] = []
+    if options.account:
+        args.append(("--account", options.account))
+    args += [
         ("--time", options.time),
         ("--mem-per-cpu", options.mem_per_core),
         ("--output", options.log_path),

--- a/scripts/slurm.py
+++ b/scripts/slurm.py
@@ -18,6 +18,7 @@ from PyExpUtils.runner.utils import approximate_cost
 from PyExpUtils.utils.generator import group
 from runner.Slurm import (
     SingleNodeOptions,
+    auto_detect_account,
     buildParallel,
     fromFile,
     get_script_name,
@@ -39,6 +40,12 @@ parser.add_argument("--force", action="store_true", default=False)
 parser.add_argument("--exclude", type=str, nargs="+", default=[])
 parser.add_argument("-i", "--idxs", type=int, nargs="+", default=None)
 parser.add_argument("--time", type=str, default=None)
+parser.add_argument(
+    "--account",
+    type=str,
+    default=None,
+    help="Override SLURM account (default: auto-detect via sacctmgr, random within rrg>aip>def tier).",
+)
 
 cmdline = parser.parse_args()
 
@@ -161,7 +168,13 @@ for path in missing:
         tasks = min([groupSize, len(job_indices)])
         par_tasks = max(math.ceil(tasks / slurm.sequential), 1)
         cores = math.ceil(par_tasks / tasks_per_core) * threads
-        sub = dataclasses.replace(slurm, cores=cores)
+        chosen_account = (
+            cmdline.account
+            if cmdline.account is not None
+            else (auto_detect_account() or "")
+        )
+        sub = dataclasses.replace(slurm, cores=cores, account=chosen_account)
+        print(f"  account: {chosen_account or '(none)'}")
 
         # build the executable string
         # instead of activating the venv every time, just use its python directly


### PR DESCRIPTION
## Summary

- `scripts/slurm.py` now auto-detects the SLURM account from `sacctmgr -nP show assoc user=$USER format=account`, prioritizing `rrg-` > `aip-` > `def-` and picking randomly within a tier so submissions spread across eligible accounts.
- A new `--account` CLI flag on `scripts/slurm.py` overrides auto-detection. Cluster JSONs no longer carry account info; the field has been stripped from all `clusters/*.json`.
- Per-job selection: each job in a submission re-rolls within its tier and the chosen account is printed alongside the scheduling line.
- Without `sacctmgr` (e.g. dev laptop) the warning is logged once and `--account` is omitted entirely, so `--debug` runs still work.

## Test plan

- [x] `python scripts/slurm.py --debug --cluster clusters/fir-cpu-5h.json --runs 1 -e <experiment.json> --idxs 0` on a laptop without sacctmgr → warning printed, `account: (none)` per job, no `--account=` in flag string.
- [x] Same with `--account rrg-whitem` → per-job line and final flags both contain `rrg-whitem`.
- [x] Mocked `sacctmgr` output with two `rrg-*` candidates → `auto_detect_account()` distributes ~50/50 over 1000 calls.
- [x] All 97 cluster JSONs still parse after the strip.
- [ ] **On fir** (`rrg-whitem` is the only `rrg-` candidate): same command → `--account=rrg-whitem` appears.
- [ ] **On vulcan**: → `--account=aip-amw8` appears.

## Notes

`scripts/local_node_venv.sh` and the per-experiment `*_job.sh` files still hardcode `--account=`; called out in the README. A separate parallel PR is consolidating time-only cluster config variants.