### PR TITLE
feat: configurable dormancy probe site + DQN_ReDo_PostLNScore variant

### DIFF
--- a/experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/9/DQN_ReDo_PostLNScore.json
+++ b/experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/9/DQN_ReDo_PostLNScore.json
@@ -1,0 +1,56 @@
+{
+    "agent": "DQN_ReDo_PostLNScore",
+    "problem": "Foragax",
+    "total_steps": 1000000,
+    "episode_cutoff": -1,
+    "metaParameters": {
+        "epsilon": [0.05, 0.1, 0.25],
+        "target_refresh": 128,
+        "buffer_size": 1000,
+        "buffer_min_size": 50,
+        "batch": 32,
+        "environment": {
+            "env_id": "ForagaxSquareWaveTwoBiome-v11",
+            "aperture_size": 9,
+            "observation_type": "color"
+        },
+        "experiment": {
+            "seed_offset": 1000000
+        },
+        "gamma": 0.99,
+        "optimizer": {
+            "name": "Adam",
+            "alpha": [
+                0.003,
+                0.001,
+                0.0003,
+                0.0001,
+                3e-05
+            ],
+            "beta1": 0.9,
+            "beta2": 0.999,
+            "eps": 1e-5
+        },
+        "representation": {
+            "type": "ForagerNet",
+            "hidden": 64,
+            "d_hidden": 512,
+            "pre_core_layers": 1,
+            "core_layers": 1,
+            "post_core_layers": 1,
+            "conv": "None",
+            "use_layernorm": true,
+            "preactivation_layer_norm": false
+        },
+        "update_freq": 4,
+        "redo_freq": 2500,
+        "redo_threshold": [
+            0,
+            0.01,
+            0.025,
+            0.1
+        ],
+        "redo_reset_layernorm": true,
+        "redo_score_after_ln": true
+    }
+}

--- a/experiments/XN33/foragax/ForagaxSquareWaveTwoBiome-v11/9/DQN_ReDo_PostLNScore.json
+++ b/experiments/XN33/foragax/ForagaxSquareWaveTwoBiome-v11/9/DQN_ReDo_PostLNScore.json
@@ -1,0 +1,45 @@
+{
+    "agent": "DQN_ReDo_PostLNScore",
+    "problem": "Foragax",
+    "total_steps": 10000000,
+    "episode_cutoff": -1,
+    "metaParameters": {
+        "epsilon": 0.1,
+        "target_refresh": 128,
+        "buffer_size": 1000,
+        "buffer_min_size": 50,
+        "batch": 32,
+        "environment": {
+            "env_id": "ForagaxSquareWaveTwoBiome-v11",
+            "aperture_size": 9,
+            "observation_type": "color"
+        },
+        "experiment": {
+            "seed_offset": 0
+        },
+        "gamma": 0.99,
+        "optimizer": {
+            "name": "Adam",
+            "alpha": 0.001,
+            "beta1": 0.9,
+            "beta2": 0.999,
+            "eps": 1e-05
+        },
+        "representation": {
+            "type": "ForagerNet",
+            "hidden": 64,
+            "d_hidden": 512,
+            "pre_core_layers": 1,
+            "core_layers": 1,
+            "post_core_layers": 1,
+            "conv": "None",
+            "use_layernorm": true,
+            "preactivation_layer_norm": false
+        },
+        "update_freq": 4,
+        "redo_freq": 2500,
+        "redo_threshold": 0.025,
+        "redo_reset_layernorm": true,
+        "redo_score_after_ln": true
+    }
+}

--- a/src/algorithms/nn/DQN_ReDo.py
+++ b/src/algorithms/nn/DQN_ReDo.py
@@ -79,6 +79,17 @@ class DQN_ReDo(DQN):
 
         self._reset_ln = bool(params.get("redo_reset_layernorm", True))
         self._use_ln = bool(self.rep_params.get("use_layernorm", False))
+        self._preact_ln = bool(self.rep_params.get("preactivation_layer_norm", True))
+        # By default we probe dormancy at the ReLU output. In post-act LN the
+        # actual signal that reaches the next layer is post-LN, so the user can
+        # opt to score there instead via redo_score_after_ln.
+        self._score_after_ln = bool(params.get("redo_score_after_ln", False))
+        if self._score_after_ln and not (self._use_ln and not self._preact_ln):
+            raise NotImplementedError(
+                "redo_score_after_ln=true is only meaningful for post-activation "
+                "LayerNorm. Got use_layernorm="
+                f"{self._use_ln}, preactivation_layer_norm={self._preact_ln}."
+            )
         # Observe-only mode (redo_apply=false): compute dormant_neurons but skip
         # the param/optim recycle. Lets us instrument vanilla DQN with the same
         # logging path so the comparison baseline shares this agent's encoder.
@@ -109,10 +120,15 @@ class DQN_ReDo(DQN):
                     f"(got {stage_name}_layers={n_layers}). "
                     "Multi-layer per stage walks are not implemented."
                 )
+            # ReLU is a free function, so accumulatingSequence uses its bare
+            # __name__ for every stage. LayerNorm is a Haiku module and gets
+            # globally indexed by Haiku (layer_norm, layer_norm_1, ...), so its
+            # probe key must use the same ln_idx that names the params.
+            probe = ln_name(ln_idx) if self._score_after_ln else "relu"
             self._stage_plan.append(
                 {
                     "stage": stage_name,
-                    "act_key": f"{stage_name}/relu",
+                    "act_key": f"{stage_name}/{probe}",
                     "linear_name": linear_name(linear_idx),
                     "ln_name": ln_name(ln_idx) if self._use_ln else None,
                 }


### PR DESCRIPTION
## Summary
Stacks on #172. Lets us compare the existing dormancy-probe-at-ReLU behavior against probing at the post-LN output for post-act LayerNorm configurations.

- Adds \`redo_score_after_ln\` (default \`false\`) to DQN_ReDo. When \`true\` with post-activation LayerNorm, the score is computed on the post-LN output rather than the pre-LN ReLU output.
- Disallowed (with an explicit \`NotImplementedError\`) for pre-act or no-LN configs, since both already score where the next layer sees them.
- Restores \`self._preact_ln\` (deleted in #172) so the new flag can validate against the LN placement.
- Updates the probe \`act_key\` to use Haiku's globally-indexed LayerNorm names (\`layer_norm\`, \`layer_norm_1\`, \`layer_norm_2\`) when scoring post-LN — ReLU stays as the bare \`relu\` since it's a free function in the sequence.
- Adds sweep + production stub configs for \`DQN_ReDo_PostLNScore\`. They mirror \`DQN_ReDo\` (post-act LN) but set \`redo_score_after_ln: true\`. Pairs with the existing \`DQN_ReDo\` for the comparison.

## Why
In post-act LN (\`Linear → ReLU → LN → next_layer\`), the existing probe at the ReLU output measures the neuron's intrinsic deadness, not the signal that actually reaches the next layer. LN's per-neuron scale/offset can rescue a dead-looking neuron or mask a live one. Letting the score location be the same place the next layer reads from gives a more architecture-coherent definition of dormancy under post-act LN.

## Test plan
- [x] Smoke run \`continuing_main.py --max_steps 50000\` on \`DQN_ReDo_PostLNScore.json\` (sweep, idx 0): completes; npz contains \`dormant_neurons\`; values in [0, 1] (run with \`redo_threshold=0\` so all zeros, expected — LN normalizes activations so scores rarely fall to exact zero).
- [x] Smoke run \`continuing_main.py --max_steps 50000\` on \`DQN_ReDo.json\` (production, score-at-ReLU path): unchanged behavior, dormant_neurons in [0.0, 0.24] as before.
- [ ] Configuration validation: setting \`redo_score_after_ln: true\` with \`use_layernorm: false\` raises \`NotImplementedError\`.
- [ ] After sweep runs, hypers.py picks separate optimal hypers for the two variants.

## Stacking note
Built on top of \`chore/dqn-redo-review-followups\` (#172). Will rebase to \`main\` once #172 lands.