### PR TITLE
feat: XN33 sweep slurm.sh + DQN_ReDo_PostLNScore configs

### DIFF
--- a/experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/9/DQN_ReDo_PostLNScore.json
+++ b/experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/9/DQN_ReDo_PostLNScore.json
@@ -1,0 +1,56 @@
+{
+    "agent": "DQN_ReDo_PostLNScore",
+    "problem": "Foragax",
+    "total_steps": 1000000,
+    "episode_cutoff": -1,
+    "metaParameters": {
+        "epsilon": [0.05, 0.1, 0.25],
+        "target_refresh": 128,
+        "buffer_size": 1000,
+        "buffer_min_size": 50,
+        "batch": 32,
+        "environment": {
+            "env_id": "ForagaxSquareWaveTwoBiome-v11",
+            "aperture_size": 9,
+            "observation_type": "color"
+        },
+        "experiment": {
+            "seed_offset": 1000000
+        },
+        "gamma": 0.99,
+        "optimizer": {
+            "name": "Adam",
+            "alpha": [
+                0.003,
+                0.001,
+                0.0003,
+                0.0001,
+                3e-05
+            ],
+            "beta1": 0.9,
+            "beta2": 0.999,
+            "eps": 1e-5
+        },
+        "representation": {
+            "type": "ForagerNet",
+            "hidden": 64,
+            "d_hidden": 512,
+            "pre_core_layers": 1,
+            "core_layers": 1,
+            "post_core_layers": 1,
+            "conv": "None",
+            "use_layernorm": true,
+            "preactivation_layer_norm": false
+        },
+        "update_freq": 4,
+        "redo_freq": 2500,
+        "redo_threshold": [
+            0,
+            0.01,
+            0.025,
+            0.1
+        ],
+        "redo_reset_layernorm": true,
+        "redo_score_after_ln": true
+    }
+}

--- a/experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/slurm.sh
+++ b/experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/slurm.sh
@@ -1,0 +1,7 @@
+for fov in 9;
+do
+    python scripts/slurm.py --cluster clusters/vulcan-gpu-vmap-256.json --time 03:00:00 --runs 10 --entry src/continuing_main.py --force -e experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/${fov}/DQN.json
+    python scripts/slurm.py --cluster clusters/vulcan-gpu-vmap-256.json --time 03:00:00 --runs 10 --entry src/continuing_main.py --force -e experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/${fov}/DQN_ReDo.json
+    python scripts/slurm.py --cluster clusters/vulcan-gpu-vmap-256.json --time 03:00:00 --runs 10 --entry src/continuing_main.py --force -e experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/${fov}/DQN_ReDo_PreActLN.json
+    python scripts/slurm.py --cluster clusters/vulcan-gpu-vmap-256.json --time 03:00:00 --runs 10 --entry src/continuing_main.py --force -e experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/${fov}/DQN_ReDo_PostLNScore.json
+done

--- a/experiments/XN33/foragax/ForagaxSquareWaveTwoBiome-v11/9/DQN_ReDo_PostLNScore.json
+++ b/experiments/XN33/foragax/ForagaxSquareWaveTwoBiome-v11/9/DQN_ReDo_PostLNScore.json
@@ -1,0 +1,45 @@
+{
+    "agent": "DQN_ReDo_PostLNScore",
+    "problem": "Foragax",
+    "total_steps": 10000000,
+    "episode_cutoff": -1,
+    "metaParameters": {
+        "epsilon": 0.1,
+        "target_refresh": 128,
+        "buffer_size": 1000,
+        "buffer_min_size": 50,
+        "batch": 32,
+        "environment": {
+            "env_id": "ForagaxSquareWaveTwoBiome-v11",
+            "aperture_size": 9,
+            "observation_type": "color"
+        },
+        "experiment": {
+            "seed_offset": 0
+        },
+        "gamma": 0.99,
+        "optimizer": {
+            "name": "Adam",
+            "alpha": 0.001,
+            "beta1": 0.9,
+            "beta2": 0.999,
+            "eps": 1e-05
+        },
+        "representation": {
+            "type": "ForagerNet",
+            "hidden": 64,
+            "d_hidden": 512,
+            "pre_core_layers": 1,
+            "core_layers": 1,
+            "post_core_layers": 1,
+            "conv": "None",
+            "use_layernorm": true,
+            "preactivation_layer_norm": false
+        },
+        "update_freq": 4,
+        "redo_freq": 2500,
+        "redo_threshold": 0.025,
+        "redo_reset_layernorm": true,
+        "redo_score_after_ln": true
+    }
+}

--- a/src/algorithms/nn/DQN_ReDo.py
+++ b/src/algorithms/nn/DQN_ReDo.py
@@ -79,6 +79,17 @@ class DQN_ReDo(DQN):
 
         self._reset_ln = bool(params.get("redo_reset_layernorm", True))
         self._use_ln = bool(self.rep_params.get("use_layernorm", False))
+        self._preact_ln = bool(self.rep_params.get("preactivation_layer_norm", True))
+        # By default we probe dormancy at the ReLU output. In post-act LN the
+        # actual signal that reaches the next layer is post-LN, so the user can
+        # opt to score there instead via redo_score_after_ln.
+        self._score_after_ln = bool(params.get("redo_score_after_ln", False))
+        if self._score_after_ln and not (self._use_ln and not self._preact_ln):
+            raise NotImplementedError(
+                "redo_score_after_ln=true is only meaningful for post-activation "
+                "LayerNorm. Got use_layernorm="
+                f"{self._use_ln}, preactivation_layer_norm={self._preact_ln}."
+            )
         # Observe-only mode (redo_apply=false): compute dormant_neurons but skip
         # the param/optim recycle. Lets us instrument vanilla DQN with the same
         # logging path so the comparison baseline shares this agent's encoder.
@@ -109,10 +120,15 @@ class DQN_ReDo(DQN):
                     f"(got {stage_name}_layers={n_layers}). "
                     "Multi-layer per stage walks are not implemented."
                 )
+            # ReLU is a free function, so accumulatingSequence uses its bare
+            # __name__ for every stage. LayerNorm is a Haiku module and gets
+            # globally indexed by Haiku (layer_norm, layer_norm_1, ...), so its
+            # probe key must use the same ln_idx that names the params.
+            probe = ln_name(ln_idx) if self._score_after_ln else "relu"
             self._stage_plan.append(
                 {
                     "stage": stage_name,
-                    "act_key": f"{stage_name}/relu",
+                    "act_key": f"{stage_name}/{probe}",
                     "linear_name": linear_name(linear_idx),
                     "ln_name": ln_name(ln_idx) if self._use_ln else None,
                 }


### PR DESCRIPTION
## Summary
Schedules the XN33/ForagaxSquareWaveTwoBiome-v11 sweep for DQN and three DQN_ReDo variants, and bundles in the DQN_ReDo_PostLNScore agent-code change + configs that were stranded on the \`chore/dqn-redo-review-followups\` branch when #174 was merged into that base instead of into main.

Files:
- \`experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/slurm.sh\` (new): four scheduling lines for \`DQN.json\`, \`DQN_ReDo.json\`, \`DQN_ReDo_PreActLN.json\`, \`DQN_ReDo_PostLNScore.json\`. Same cluster / time / runs as the X32 and E136 siblings: \`vulcan-gpu-vmap-256\`, 3h, 10 seeds.
- \`src/algorithms/nn/DQN_ReDo.py\` (cherry-picked from #174): adds \`redo_score_after_ln\` and restores \`self._preact_ln\` to validate it. Default behavior unchanged.
- \`experiments/XN33/foragax-sweep/.../9/DQN_ReDo_PostLNScore.json\` and \`experiments/XN33/foragax/.../9/DQN_ReDo_PostLNScore.json\` (new): sweep + production stub for the new variant.

## Why bundled
PR #174 was stacked on \`chore/dqn-redo-review-followups\` and merged into that branch rather than \`main\`. The slurm.sh's fourth line references \`DQN_ReDo_PostLNScore.json\`, which needs to land on main alongside the script. Easiest path is one PR.

## Test plan
- [x] Smoke run \`continuing_main.py --max_steps 50000\` on \`DQN_ReDo_PostLNScore.json\` (sweep, idx 0): completes; \`dormant_neurons\` in [0, 1].
- [x] Smoke run on \`DQN_ReDo.json\` (default score-at-ReLU): unchanged behavior.
- [ ] On the cluster, \`bash experiments/XN33/foragax-sweep/ForagaxSquareWaveTwoBiome-v11/slurm.sh\` schedules all four agents successfully.