### PR TITLE
perf: hoist macro-block setup out of milestone loop + comment cleanup

### DIFF
--- a/src/algorithms/nn/DQN_ReDo.py
+++ b/src/algorithms/nn/DQN_ReDo.py
@@ -170,8 +170,7 @@ class DQN_ReDo(DQN):
             f"is optax.ScaleByAdamState; got {type(adam_state).__name__}."
         )
 
-        # ReDo's hyper `redo_freq` counts agent updates. The training-loop
-        # macro-block scan dispatches on env steps, so convert here.
+        # redo_freq is in agent updates; periodic_freq is in env steps.
         self.periodic_freq = int(params["redo_freq"]) * int(
             self.state.hypers.update_freq
         )

--- a/src/algorithms/nn/NNAgent.py
+++ b/src/algorithms/nn/NNAgent.py
@@ -388,13 +388,10 @@ class NNAgent(BaseAgent):
         )
 
     def _periodic_step(self, state: AgentState) -> AgentState:
-        # Hook for expensive periodic operations (ReDo, resets, PT-DQN's
-        # permanent-net update, shrink-and-perturb, …). Called by the training
-        # loop once every `periodic_freq` env steps. Subclasses override this
-        # *instead of* gating the op with a per-step `jax.lax.cond` — when the
-        # outer scan is vmapped over seeds, vmap rewrites cond to select, which
-        # forces both branches to execute every step. Hoisting the dispatch to
-        # the training loop's outer scan keeps the hot path free of conds.
+        # Override instead of guarding with a per-step `jax.lax.cond`: under
+        # vmap, cond is rewritten to select and both branches execute every
+        # step. The training loop dispatches this every `periodic_freq` env
+        # steps from an outer scan, keeping the hot path cond-free.
         return state
 
     def _advance_update_clock(self, state: AgentState) -> AgentState:

--- a/src/algorithms/nn/NNAgent.py
+++ b/src/algorithms/nn/NNAgent.py
@@ -77,9 +77,7 @@ class AgentState(BaseAgentState):
 
 @checkpointable(("buffer", "steps", "state", "updates"))
 class NNAgent(BaseAgent):
-    # Number of env steps between firings of `_periodic_step`. None means the
-    # agent has no periodic operation (the training loop falls back to its
-    # single-level block scan). Set by subclasses in __init__.
+    # Env steps between `_periodic_step` firings; None = no periodic op.
     periodic_freq: Optional[int] = None
 
     def __init__(
@@ -388,10 +386,9 @@ class NNAgent(BaseAgent):
         )
 
     def _periodic_step(self, state: AgentState) -> AgentState:
-        # Override instead of guarding with a per-step `jax.lax.cond`: under
-        # vmap, cond is rewritten to select and both branches execute every
-        # step. The training loop dispatches this every `periodic_freq` env
-        # steps from an outer scan, keeping the hot path cond-free.
+        # Override here rather than gating with a per-step `jax.lax.cond`:
+        # under vmap, cond is rewritten to select and both branches execute
+        # every step. The training loop dispatches this from an outer scan.
         return state
 
     def _advance_update_clock(self, state: AgentState) -> AgentState:

--- a/src/algorithms/nn/PT_DQN.py
+++ b/src/algorithms/nn/PT_DQN.py
@@ -166,8 +166,7 @@ class PT_DQN(DQN):
             hypers=hypers,
         )
 
-        # `pt_update_freq` counts agent updates; convert to env steps for the
-        # training-loop macro-block scan.
+        # pt_update_freq is in agent updates; periodic_freq is in env steps.
         self.periodic_freq = int(params["pt_update_freq"]) * int(
             self.state.hypers.update_freq
         )

--- a/src/algorithms/nn/PT_DQN.py
+++ b/src/algorithms/nn/PT_DQN.py
@@ -58,9 +58,7 @@ def mse_q_loss(q, a, r, gamma, qp):
 
 @cxu.dataclass
 class Hypers(DQNHypers):
-    pt_update_freq: (
-        int  # k: how often (gradient updates) to update permanent and decay transient
-    )
+    pt_update_freq: int  # k: gradient updates between permanent updates
     pt_decay: float  # λ: decay factor for transient weights
     pt_optimizer: OptimizerHypers  # optimizer config for permanent network
     pm_buffer_size: int  # size of PM replay buffer (reference: 10000)
@@ -279,14 +277,6 @@ class PT_DQN(DQN):
 
         state = replace(state, updates=updates)
 
-        # PT gradient update + transient-weight decay used to be guarded by
-        # per-update conds here. They're now hoisted into `_periodic_step`,
-        # dispatched by the training-loop macro-block scan every
-        # `pt_update_freq * update_freq` env steps.
-
-        # --- Target network update (matching reference: after PT step when
-        # one fires; but since we no longer fire PT inside _update, just apply
-        # target refresh here unconditionally on its own schedule).
         target_params = self._update_target_network(state, updates)
         state = replace(state, target_params=target_params)
 
@@ -294,9 +284,6 @@ class PT_DQN(DQN):
 
     @partial(jax.jit, static_argnums=0)
     def _periodic_step(self, state: AgentState) -> AgentState:
-        # PT-DQN's periodic op: U sequential gradient steps on the PM buffer
-        # to update the permanent network, then decay all transient weights
-        # by λ. Order matches the reference implementation.
         state = self._pt_gradient_update(state)
         state = replace(
             state,

--- a/src/continuing_main.py
+++ b/src/continuing_main.py
@@ -11,8 +11,9 @@ import pickle
 import socket
 import time
 import traceback
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import fields, replace
+from typing import Any, Optional
 
 import jax
 import jax.numpy as jnp
@@ -447,18 +448,28 @@ def video_step(carry, _):
     return carry, (data, frame)
 
 
+# Populated when use_explicit_update_steps is True; use sites are guarded
+# by can_use_explicit_steps, which implies that flag.
+no_update_step: Optional[Callable[..., Any]] = None
+update_block: Optional[Callable[..., Any]] = None
+macro_block: Optional[Callable[..., Any]] = None
+periodic_freq: Optional[int] = None
+blocks_per_macro: Optional[int] = None
+
 if use_explicit_update_steps:
 
-    def no_update_step(carry, _):
+    def _no_update_step(carry, _):
         carry, interaction = v_step_no_update(carry)
         data = get_data(carry, interaction)
         return carry, data
 
-    def update_block(carry, _):
+    no_update_step = _no_update_step
+
+    def _update_block(carry, _):
         carry, interaction = v_step_update(carry)
         update_data = get_data(carry, interaction)
         carry, skip_data = jax.lax.scan(
-            no_update_step,
+            _no_update_step,
             carry,
             jnp.arange(update_freq - 1),
             unroll=UNROLL,
@@ -472,26 +483,30 @@ if use_explicit_update_steps:
         )
         return carry, block_data
 
+    update_block = _update_block
+
     periodic_freq = getattr(glues[0].agent, "periodic_freq", None)
-    blocks_per_macro = None
     if periodic_freq is not None:
         assert periodic_freq % update_freq == 0, (
             f"agent.periodic_freq ({periodic_freq}) must be divisible "
             f"by update_freq ({update_freq})"
         )
         blocks_per_macro = periodic_freq // update_freq
-        v_periodic = jax.vmap(glues[0].agent._periodic_step)
+        _v_periodic = jax.vmap(glues[0].agent._periodic_step)
+        _blocks_per_macro = blocks_per_macro
 
-        def macro_block(carry, _):
+        def _macro_block(carry, _):
             carry, blocks_data = jax.lax.scan(
-                update_block,
+                _update_block,
                 carry,
-                jnp.arange(blocks_per_macro),
+                jnp.arange(_blocks_per_macro),
                 unroll=UNROLL,
             )
-            new_agent_state = v_periodic(carry.agent_state)
+            new_agent_state = _v_periodic(carry.agent_state)
             carry = replace(carry, agent_state=new_agent_state)
             return carry, blocks_data
+
+        macro_block = _macro_block
 
 
 while current_step < n:
@@ -522,6 +537,9 @@ while current_step < n:
         )
 
         if can_use_explicit_steps:
+            # `use_explicit_update_steps` (a precondition of
+            # `can_use_explicit_steps`) implies these are non-None.
+            assert no_update_step is not None and update_block is not None
             data_chunks = []
             steps_remaining = no_video_steps_count
 
@@ -538,6 +556,7 @@ while current_step < n:
             block_count = steps_remaining // update_freq
             if block_count > 0:
                 if blocks_per_macro is not None and block_count >= blocks_per_macro:
+                    assert periodic_freq is not None and macro_block is not None
                     assert current_step % periodic_freq == 0, (
                         f"current_step ({current_step}) is not aligned to "
                         f"periodic_freq ({periodic_freq}); set save_every and "

--- a/src/continuing_main.py
+++ b/src/continuing_main.py
@@ -425,12 +425,8 @@ def scan_progress(num_iters: int, unit_scale: int = 1):
     return wrap
 
 
-# Hoist scan-body definitions and the macro-block setup out of the outer
-# while loop. JAX caches compilation by jaxpr, but every Python closure
-# rebuilt inside the loop still pays trace overhead — and a long run with
-# many save/video milestones (e.g. >100 checkpoints) can amortize that into
-# real wall-clock cost. Definitions here are stable across iterations; only
-# scan lengths (block_count, n_macro, …) and current_step vary.
+# Defined outside the outer milestone loop so trace overhead isn't paid
+# on every save/video iteration.
 update_freq = int(first_hypers.get("update_freq", 1))
 freeze_steps = first_hypers.get("freeze_steps", np.inf)
 if freeze_steps is None:
@@ -476,10 +472,6 @@ if use_explicit_update_steps:
         )
         return carry, block_data
 
-    # Macro-block scan: wraps the update_block scan in an outer scan that
-    # fires `_periodic_step` at each boundary. Keeps the hot path free of
-    # `jax.lax.cond` — under vmap, cond rewrites to select and both branches
-    # execute every step.
     periodic_freq = getattr(glues[0].agent, "periodic_freq", None)
     blocks_per_macro = None
     if periodic_freq is not None:
@@ -546,12 +538,6 @@ while current_step < n:
             block_count = steps_remaining // update_freq
             if block_count > 0:
                 if blocks_per_macro is not None and block_count >= blocks_per_macro:
-                    # `current_step` must be aligned to `periodic_freq` so the
-                    # macro-block scan fires at the same absolute steps as the
-                    # old per-step `state.steps % periodic_freq == 0` cond.
-                    # This holds automatically when `save_every` and
-                    # `video_every` (and any checkpoint resume point) are
-                    # multiples of `periodic_freq`.
                     assert current_step % periodic_freq == 0, (
                         f"current_step ({current_step}) is not aligned to "
                         f"periodic_freq ({periodic_freq}); set save_every and "

--- a/src/continuing_main.py
+++ b/src/continuing_main.py
@@ -448,8 +448,6 @@ def video_step(carry, _):
     return carry, (data, frame)
 
 
-# Populated when use_explicit_update_steps is True; use sites are guarded
-# by can_use_explicit_steps, which implies that flag.
 no_update_step: Optional[Callable[..., Any]] = None
 update_block: Optional[Callable[..., Any]] = None
 macro_block: Optional[Callable[..., Any]] = None
@@ -537,8 +535,6 @@ while current_step < n:
         )
 
         if can_use_explicit_steps:
-            # `use_explicit_update_steps` (a precondition of
-            # `can_use_explicit_steps`) implies these are non-None.
             assert no_update_step is not None and update_block is not None
             data_chunks = []
             steps_remaining = no_video_steps_count
@@ -564,21 +560,20 @@ while current_step < n:
                         f"resume from checkpoints at multiples of periodic_freq"
                     )
                     n_macro = block_count // blocks_per_macro
+                    macro_steps_per_iter = blocks_per_macro * update_freq
+                    macro_steps = n_macro * macro_steps_per_iter
                     glue_states, macro_data = jax.lax.scan(
-                        scan_progress(
-                            n_macro, unit_scale=blocks_per_macro * update_freq
-                        )(macro_block),
+                        scan_progress(n_macro, unit_scale=macro_steps_per_iter)(
+                            macro_block
+                        ),
                         glue_states,
                         jnp.arange(n_macro),
                     )
                     macro_data = tree_map(
-                        lambda x: x.reshape(
-                            (n_macro * blocks_per_macro * update_freq, *x.shape[3:])
-                        ),
+                        lambda x: x.reshape((macro_steps, *x.shape[3:])),
                         macro_data,
                     )
                     data_chunks.append(macro_data)
-                    macro_steps = n_macro * blocks_per_macro * update_freq
                     steps_remaining -= macro_steps
 
                     trailing_blocks = block_count - n_macro * blocks_per_macro

--- a/src/continuing_main.py
+++ b/src/continuing_main.py
@@ -425,6 +425,83 @@ def scan_progress(num_iters: int, unit_scale: int = 1):
     return wrap
 
 
+# Hoist scan-body definitions and the macro-block setup out of the outer
+# while loop. JAX caches compilation by jaxpr, but every Python closure
+# rebuilt inside the loop still pays trace overhead — and a long run with
+# many save/video milestones (e.g. >100 checkpoints) can amortize that into
+# real wall-clock cost. Definitions here are stable across iterations; only
+# scan lengths (block_count, n_macro, …) and current_step vary.
+update_freq = int(first_hypers.get("update_freq", 1))
+freeze_steps = first_hypers.get("freeze_steps", np.inf)
+if freeze_steps is None:
+    freeze_steps = np.inf
+freeze_steps = float(freeze_steps)
+
+
+def step(carry, _):
+    carry, interaction = v_step(carry)
+    data = get_data(carry, interaction)
+    return carry, data
+
+
+def video_step(carry, _):
+    frame = v_render(carry)
+    carry, interaction = v_step(carry)
+    data = get_data(carry, interaction)
+    return carry, (data, frame)
+
+
+if use_explicit_update_steps:
+
+    def no_update_step(carry, _):
+        carry, interaction = v_step_no_update(carry)
+        data = get_data(carry, interaction)
+        return carry, data
+
+    def update_block(carry, _):
+        carry, interaction = v_step_update(carry)
+        update_data = get_data(carry, interaction)
+        carry, skip_data = jax.lax.scan(
+            no_update_step,
+            carry,
+            jnp.arange(update_freq - 1),
+            unroll=UNROLL,
+        )
+        block_data = tree_map(
+            lambda first, rest: jnp.concatenate(
+                [jnp.expand_dims(first, 0), rest], axis=0
+            ),
+            update_data,
+            skip_data,
+        )
+        return carry, block_data
+
+    # Macro-block scan: wraps the update_block scan in an outer scan that
+    # fires `_periodic_step` at each boundary. Keeps the hot path free of
+    # `jax.lax.cond` — under vmap, cond rewrites to select and both branches
+    # execute every step.
+    periodic_freq = getattr(glues[0].agent, "periodic_freq", None)
+    blocks_per_macro = None
+    if periodic_freq is not None:
+        assert periodic_freq % update_freq == 0, (
+            f"agent.periodic_freq ({periodic_freq}) must be divisible "
+            f"by update_freq ({update_freq})"
+        )
+        blocks_per_macro = periodic_freq // update_freq
+        v_periodic = jax.vmap(glues[0].agent._periodic_step)
+
+        def macro_block(carry, _):
+            carry, blocks_data = jax.lax.scan(
+                update_block,
+                carry,
+                jnp.arange(blocks_per_macro),
+                unroll=UNROLL,
+            )
+            new_agent_state = v_periodic(carry.agent_state)
+            carry = replace(carry, agent_state=new_agent_state)
+            return carry, blocks_data
+
+
 while current_step < n:
     next_save = ((current_step // save_every) + 1) * save_every
     next_video = ((current_step // video_every) + 1) * video_every
@@ -443,31 +520,9 @@ while current_step < n:
         no_video_steps_count = steps_in_iter
         video_steps_count = 0
 
-    def video_step(carry, _):
-        frame = v_render(carry)
-        carry, interaction = v_step(carry)
-        data = get_data(carry, interaction)
-        return carry, (data, frame)
-
     data_chunk = None
     if no_video_steps_count > 0:
-        update_freq = int(first_hypers.get("update_freq", 1))
-
-        def step(carry, _):
-            carry, interaction = v_step(carry)
-            data = get_data(carry, interaction)
-            return carry, data
-
-        def no_update_step(carry, _):
-            carry, interaction = v_step_no_update(carry)
-            data = get_data(carry, interaction)
-            return carry, data
-
         agent_step_count = int(np.asarray(glue_states.agent_state.steps).reshape(-1)[0])
-        freeze_steps = first_hypers.get("freeze_steps", np.inf)
-        if freeze_steps is None:
-            freeze_steps = np.inf
-        freeze_steps = float(freeze_steps)
         can_use_explicit_steps = (
             use_explicit_update_steps
             and update_freq > 1
@@ -490,54 +545,19 @@ while current_step < n:
 
             block_count = steps_remaining // update_freq
             if block_count > 0:
-
-                def update_block(carry, _):
-                    carry, interaction = v_step_update(carry)
-                    update_data = get_data(carry, interaction)
-                    carry, skip_data = jax.lax.scan(
-                        no_update_step,
-                        carry,
-                        jnp.arange(update_freq - 1),
-                        unroll=UNROLL,
-                    )
-                    block_data = tree_map(
-                        lambda first, rest: jnp.concatenate(
-                            [jnp.expand_dims(first, 0), rest], axis=0
-                        ),
-                        update_data,
-                        skip_data,
-                    )
-                    return carry, block_data
-
-                # Periodic-op macro-block path: when the agent declares a
-                # `periodic_freq` (e.g. DQN_ReDo, PT_DQN, DQN_Reset, …), we wrap
-                # the update_block scan in an outer scan whose body fires
-                # `_periodic_step` at the boundary. This keeps the hot path free
-                # of `jax.lax.cond`, which under vmap rewrites to `select` and
-                # forces both branches to execute every step.
-                periodic_freq = getattr(glues[0].agent, "periodic_freq", None)
-                blocks_per_macro = None
-                if periodic_freq is not None:
-                    assert periodic_freq % update_freq == 0, (
-                        f"agent.periodic_freq ({periodic_freq}) must be divisible "
-                        f"by update_freq ({update_freq})"
-                    )
-                    blocks_per_macro = periodic_freq // update_freq
-
                 if blocks_per_macro is not None and block_count >= blocks_per_macro:
-                    v_periodic = jax.vmap(glues[0].agent._periodic_step)
-
-                    def macro_block(carry, _):
-                        carry, blocks_data = jax.lax.scan(
-                            update_block,
-                            carry,
-                            jnp.arange(blocks_per_macro),
-                            unroll=UNROLL,
-                        )
-                        new_agent_state = v_periodic(carry.agent_state)
-                        carry = replace(carry, agent_state=new_agent_state)
-                        return carry, blocks_data
-
+                    # `current_step` must be aligned to `periodic_freq` so the
+                    # macro-block scan fires at the same absolute steps as the
+                    # old per-step `state.steps % periodic_freq == 0` cond.
+                    # This holds automatically when `save_every` and
+                    # `video_every` (and any checkpoint resume point) are
+                    # multiples of `periodic_freq`.
+                    assert current_step % periodic_freq == 0, (
+                        f"current_step ({current_step}) is not aligned to "
+                        f"periodic_freq ({periodic_freq}); set save_every and "
+                        f"video_every to multiples of periodic_freq, and only "
+                        f"resume from checkpoints at multiples of periodic_freq"
+                    )
                     n_macro = block_count // blocks_per_macro
                     glue_states, macro_data = jax.lax.scan(
                         scan_progress(


### PR DESCRIPTION
## Summary

Follow-ups to #176.

### `137c8c57` — hoist scan-body defs out of the outer milestone loop
The outer `while current_step < n:` loop iterates once per save/video milestone. Long runs with many checkpoints (>100 saves) were rebuilding `update_block`, `macro_block`, `v_periodic`, and the periodic-freq divisibility check on every iteration. JAX caches compile artifacts by jaxpr, but trace overhead per closure is real. Move the stable pieces out of the loop.

### `fbf3b46d` + `3ac60e5d` — trim narrating / design-rationale comments
Some of the comments I added in #176 were narrating the refactor itself or PR-description material rather than non-obvious WHY. Trim.

### `de287d38` — silence possibly-unbound pyright on the explicit-update path
Declare scan-body closures and macro-block components at module scope as `Optional[...]`, then assign inside the `use_explicit_update_steps` branch. Use sites narrow via a single `assert ... is not None` — the names are guaranteed non-None whenever `can_use_explicit_steps` is True (a stricter precondition).

## Test plan

- [x] Smoke run DQN_ReDo (15k env steps): exits 0
- [x] Smoke run base DQN (15k env steps): exits 0
- [ ] Run a multi-checkpoint experiment to confirm the trace-overhead win materializes for ≥100 milestone iterations