### PR TITLE
fix: unpack six values from foragax step for gymnax 1.0

### DIFF
--- a/src/environments/Foragax.py
+++ b/src/environments/Foragax.py
@@ -31,16 +31,16 @@ class Foragax(BaseEnvironment):
         return state, obs
 
     def step(self, action: jax.Array):
-        self.state, (obs, reward, done, done, info) = self._step(
+        self.state, (obs, reward, terminated, truncated, info) = self._step(
             self.state,
             action,
         )
-        return (obs, reward, done, done, info)
+        return (obs, reward, terminated, truncated, info)
 
     @partial(jax.jit, static_argnums=0)
     def _step(self, state: EnvState, action: jax.Array):
         state.key, env_step_key = jax.random.split(state.key)
-        obs, state.state, reward, done, info = self.env.step(
+        obs, state.state, reward, terminated, truncated, info = self.env.step(
             env_step_key, state.state, action
         )
-        return state, (obs, reward, done, done, info)
+        return state, (obs, reward, terminated, truncated, info)

--- a/src/rtu_ppo.py
+++ b/src/rtu_ppo.py
@@ -797,7 +797,7 @@ def env_step(runner_state, _):
         last_obs_encoded, train_state, _rng, hstate
     )
     # STEP ENV
-    obs, env_state, reward, done, info = gymnax_state.env_step(
+    obs, env_state, reward, _terminated, _truncated, info = gymnax_state.env_step(
         _rng, gymnax_state.env_state, action.squeeze(), gymnax_state.env_params
     )
     step = log_env_state.timestep + 1


### PR DESCRIPTION
Companion to **steventango/continual-foragax#104**, which migrates Foragax to gymnax 1.0.

Opened as a **draft**: merging this before that PR is released will break `main`. See *Merge order* below.

## What changes

gymnax 1.0 splits the episode-end signal, so `Environment.step` returns `(obs, state, reward, terminated, truncated, info)` instead of five values. Two places unpack it:

- **`src/environments/Foragax.py`** — the RlGlue shim. It previously passed `done` twice to fill both the terminal and truncated slots; it can now forward the real flags, which is what RlGlue actually wants.
- **`src/rtu_ppo.py:800`** — calls `env.step` **directly** rather than going through the shim, so it needs the same fix. Easy to miss. `done` was unused there, so both flags are discarded.

Without the second one, `Search-Oracle` still runs but PPO/RTU-PPO dies with:
```
ValueError: too many values to unpack (expected 5)
```

## Verification

Ran `Search-Oracle` and `PPO-RTU_LN_128_1` on `ForagaxUnendingTasks-v1` and `ForagaxNeverEndingRelearning-v1` (the new registry aliases), against pre-migration and post-migration foragax, with **jax pinned to 0.9.0.1 on both sides** so the only variable is foragax + gymnax:

- **146/146 populated arrays bitwise identical**, across all four runs — `rewards`, `pos`, `biome_id`, `biome_rank`, `biome_regret`, `object_collected_id`, `hint`, plus `policy_loss` / `value_loss` / `total_loss` and all 28 `grad_l2_*` channels.
- A further 30 arrays are all-NaN on both sides (NTK rank / churn / weight-norm, computed every 1000 steps and never populated at the run lengths used) — vacuously equal, not evidence either way.
- Determinism was confirmed first by re-running one config and getting bitwise-identical output, so "identical" is a real signal rather than noise.

## Merge order

This PR is **not standalone**. It requires a foragax release containing the gymnax 1.0 API:

1. Merge and release continual-foragax#104 (a breaking change, so expect a major bump).
2. Raise the `continual-foragax` floor in `pyproject.toml` to that release — I deliberately left the pin at `>=0.51` because the target version does not exist yet, and inventing a floor would break resolution today.
3. Then merge this.

If you would rather not sequence the two, the alternative is a version-tolerant shim that accepts either arity; say so and I will switch it.

## Known dependency conflict (not addressed here)

Once foragax requires `gymnax>=1.0.0`, `uv sync` will fail outright:

```
× No solution found: gymnax==1.0.0 depends on jax>=0.6,<0.7
  And because you require jax>=0.9.0 ... requirements are unsatisfiable.
```

gymnax 1.0's cap is conservative rather than real — it imports and runs correctly on jax 0.9.0.1, which is how the verification above was done (forced with `--no-deps`).

I tried `[tool.uv] override-dependencies = ["jax>=0.9.0"]` and **deliberately dropped it**: because uv overrides match by package name, it replaces `jax[cuda]>=0.9.0` too, silently stripping the `cuda` extra and all 32 `nvidia-*` packages from the lock. That would quietly break GPU installs, which is worse than the error it fixes. The right fix is upstream in gymnax; until then this needs a more surgical workaround.